### PR TITLE
Update retrying_async.py

### DIFF
--- a/retrying_async.py
+++ b/retrying_async.py
@@ -44,9 +44,9 @@ def callback(attempt, exc, args, kwargs, delay=0.5, *, loop):
 
 
 def retry(
-        *, fn=None, attempts=3, delay=0.5, max_delay=None, backoff=1, jitter=0, timeout=30, immutable=False,
+        *, fn=None, attempts=3, delay=0.5, max_delay=None, backoff=1, jitter=0, timeout=None, immutable=False,
         callback=callback, fallback=RetryError, retry_exceptions=(Exception,),
-        fatal_exceptions=(asyncio.CancelledError,)
+        fatal_exceptions=(asyncio.CancelledError,), logger=logger
 ):
     """
 
@@ -63,6 +63,7 @@ def retry(
     :param fallback: a callable function or a value to return when all attempts are tried.
     :param retry_exceptions:
     :param fatal_exceptions:
+    :param logger: 
     :return:
     """
     def wrapper(fn):


### PR DESCRIPTION
开放logger用于重尝错误的日志记录（有的时候需要做持久化），将timeout默认值设置为None，根据 #1 ，默认的超时时间注释不完整，容易发生TimeoutError